### PR TITLE
Fix particle accelerators

### DIFF
--- a/src/main/java/org/halvors/nuclearphysics/api/BlockPos.java
+++ b/src/main/java/org/halvors/nuclearphysics/api/BlockPos.java
@@ -27,7 +27,7 @@ public class BlockPos {
     }
 
     public BlockPos(final Entity entity) {
-        this(entity.posX, entity.posY, entity.posZ);
+        this(Math.floor(entity.posX), Math.floor(entity.posY), Math.floor(entity.posZ));
     }
 
     public BlockPos(final TileEntity tile) {


### PR DESCRIPTION
This fixes particle accelerators not turning in negative coordinates BlockPos is calculated with floor() not truncating. They still don't work completely